### PR TITLE
Use HTTPS URL in git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = git@github.com:gesinn-it-pub/docker-compose-ci.git
+	url = https://github.com/gesinn-it-pub/docker-compose-ci.git


### PR DESCRIPTION
Instead of SSH key-based auth in URL, 
use HTTPS which can be cloned anonymously.

This is the same problem encountered with SemanticDrilldown fixed here:
https://github.com/SemanticMediaWiki/SemanticDrilldown/pull/75/commits/49a116cdaf66805abf2eccd33cae5781683f022e