### PR TITLE
Use https protocol instead of git for the build submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "build"]
 	path = build
-	url = git@github.com:gesinn-it-pub/docker-compose-ci.git
+	url = https://github.com/gesinn-it-pub/docker-compose-ci.git


### PR DESCRIPTION
Initializing the git submodule on some systems ends with the error:
    fatal: Could not read from remote repository
We often initialize/update the submodules recursively, this interferes